### PR TITLE
zip analyzer -- doesn't really do what I hoped

### DIFF
--- a/uc3/src/main/edu/ucop/cdluc3/fileAnalyzer/importer/UC3ImporterRegistry.java
+++ b/uc3/src/main/edu/ucop/cdluc3/fileAnalyzer/importer/UC3ImporterRegistry.java
@@ -1,6 +1,11 @@
 package edu.ucop.cdluc3.fileAnalyzer.importer;
 
 import gov.nara.nwts.ftapp.importer.ImporterRegistry;
+import edu.georgetown.library.fileAnalyzer.filetest.MarcItemInventory;
+import edu.georgetown.library.fileAnalyzer.importer.EncodingCheck;
+import edu.georgetown.library.fileAnalyzer.importer.MarcInventory;
+import edu.georgetown.library.fileAnalyzer.importer.MarcRecValidator;
+import edu.georgetown.library.fileAnalyzer.importer.MarcSerializer;
 import gov.nara.nwts.ftapp.FTDriver;
 import gov.nara.nwts.ftapp.filetest.CounterValidation;
 
@@ -16,7 +21,13 @@ public class UC3ImporterRegistry extends ImporterRegistry {
 
 	public UC3ImporterRegistry(FTDriver dt) {
 		super(dt);
-	}
-	
+		removeImporter(CounterValidation.class);
+		add(new MarcRecValidator(dt));
+		add(new EncodingCheck(dt));
+		add(new MarcInventory(dt));
+        add(new MarcItemInventory(dt));
+		add(new MarcSerializer(dt));
+		add(new ZipAnalyzer(dt));
+	}	
 
 }

--- a/uc3/src/main/edu/ucop/cdluc3/fileAnalyzer/importer/ZipAnalyzer.java
+++ b/uc3/src/main/edu/ucop/cdluc3/fileAnalyzer/importer/ZipAnalyzer.java
@@ -1,0 +1,120 @@
+package edu.ucop.cdluc3.fileAnalyzer.importer;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TreeMap;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.apache.tika.parser.txt.CharsetDetector;
+
+import gov.nara.nwts.ftapp.ActionResult;
+import gov.nara.nwts.ftapp.FTDriver;
+import gov.nara.nwts.ftapp.Timer;
+import gov.nara.nwts.ftapp.importer.DefaultImporter;
+import gov.nara.nwts.ftapp.stats.Stats;
+import gov.nara.nwts.ftapp.stats.StatsGenerator;
+import gov.nara.nwts.ftapp.stats.StatsItem;
+import gov.nara.nwts.ftapp.stats.StatsItemConfig;
+import gov.nara.nwts.ftapp.stats.StatsItemEnum;
+
+public class ZipAnalyzer extends DefaultImporter
+{
+	// name and description of the Marc Serializer importer
+	public String toString()
+	{
+		return "Zip Analyzer";
+	}
+	
+	public String getDescription()
+	{
+		return "Zip file TOC.";
+	}
+	
+	public String getShortName()
+	{
+		return "Zip";
+	}
+
+	
+	public ZipAnalyzer(FTDriver dt)
+	{
+		super(dt);
+	}
+	
+	// resulting information to display
+	public static enum EntryProp {A, B;}
+	
+	private static enum ZipStatsItem implements StatsItemEnum
+	{
+		Key(StatsItem.makeStringStatsItem("Key", 300)),
+		Size(StatsItem.makeLongStatsItem("Size")),
+		Date(StatsItem.makeStringStatsItem("Date")),
+		Comment(StatsItem.makeStringStatsItem("Comment")),
+		Charset(StatsItem.makeStringStatsItem("Charset")),
+		Extra(StatsItem.makeStringStatsItem("Extra")),
+		Property(StatsItem.makeEnumStatsItem(EntryProp.class, "Prop").setWidth(100));
+		
+		StatsItem si;
+		
+		ZipStatsItem (StatsItem si)
+		{
+			this.si = si;
+		}
+		
+		public StatsItem si()
+		{
+			return si;
+		}
+		
+	}
+	
+	public static enum Generator implements StatsGenerator
+	{
+		INSTANCE;
+		public Stats create(String key)
+		{
+			return new Stats(details, key);
+		}
+	}
+	
+	public static StatsItemConfig details = StatsItemConfig.create(ZipStatsItem.class);
+	
+	
+	// file import rules
+	public ActionResult importFile(File selectedFile) throws IOException
+	{
+		Timer timer = new Timer();
+		TreeMap<String, Stats> types = new TreeMap<String, Stats>();
+		DateFormat df = DateFormat.getDateTimeInstance();
+		
+		try(
+				ZipInputStream zis = new ZipInputStream(new FileInputStream(selectedFile));
+			) {
+				
+				for(ZipEntry ze = zis.getNextEntry(); ze != null; ze = zis.getNextEntry()){
+					if (ze.isDirectory()) continue;
+					String key = ze.getName();
+					Stats stats = Generator.INSTANCE.create(key);
+					stats.setVal(ZipStatsItem.Size, ze.getSize());
+					stats.setVal(ZipStatsItem.Comment, ze.getComment());
+					stats.setVal(ZipStatsItem.Extra, ze.getExtra());
+					Date d = new Date(ze.getTime());
+					stats.setVal(ZipStatsItem.Date, df.format(d));
+					CharsetDetector detector = new CharsetDetector();
+					detector.setText(key.getBytes());
+					stats.setVal(ZipStatsItem.Charset, detector.detect().toString());
+					types.put(key, stats);
+				}
+			} catch (Exception e) {
+				System.err.println(e.getMessage());
+			}
+
+		return new ActionResult(selectedFile, selectedFile.getName(), this.toString(), details, types, true, timer.getDuration());
+	}  // end of ActionResult
+
+}

--- a/uc3/src/main/edu/ucop/cdluc3/fileAnalyzer/importer/ZipAnalyzer.java
+++ b/uc3/src/main/edu/ucop/cdluc3/fileAnalyzer/importer/ZipAnalyzer.java
@@ -3,18 +3,17 @@ package edu.ucop.cdluc3.fileAnalyzer.importer;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TreeMap;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import org.apache.tika.parser.txt.CharsetDetector;
-
 import gov.nara.nwts.ftapp.ActionResult;
 import gov.nara.nwts.ftapp.FTDriver;
 import gov.nara.nwts.ftapp.Timer;
+import gov.nara.nwts.ftapp.ftprop.FTPropString;
 import gov.nara.nwts.ftapp.importer.DefaultImporter;
 import gov.nara.nwts.ftapp.stats.Stats;
 import gov.nara.nwts.ftapp.stats.StatsGenerator;
@@ -39,15 +38,14 @@ public class ZipAnalyzer extends DefaultImporter
 	{
 		return "Zip";
 	}
-
+    public static final String Charsets = "charsets";
 	
 	public ZipAnalyzer(FTDriver dt)
 	{
 		super(dt);
+        ftprops.add(new FTPropString(dt, this.getClass().getSimpleName(),  Charsets, Charsets,
+                "Charsets to attempt to match", "UTF-8,ISO-8859-1"));
 	}
-	
-	// resulting information to display
-	public static enum EntryProp {A, B;}
 	
 	private static enum ZipStatsItem implements StatsItemEnum
 	{
@@ -56,8 +54,7 @@ public class ZipAnalyzer extends DefaultImporter
 		Date(StatsItem.makeStringStatsItem("Date")),
 		Comment(StatsItem.makeStringStatsItem("Comment")),
 		Charset(StatsItem.makeStringStatsItem("Charset")),
-		Extra(StatsItem.makeStringStatsItem("Extra")),
-		Property(StatsItem.makeEnumStatsItem(EntryProp.class, "Prop").setWidth(100));
+		Extra(StatsItem.makeStringStatsItem("Extra"));
 		
 		StatsItem si;
 		
@@ -92,10 +89,10 @@ public class ZipAnalyzer extends DefaultImporter
 		TreeMap<String, Stats> types = new TreeMap<String, Stats>();
 		DateFormat df = DateFormat.getDateTimeInstance();
 		
-		try(
-				ZipInputStream zis = new ZipInputStream(new FileInputStream(selectedFile));
-			) {
-				
+		for(String cs: getProperty(Charsets, "UTF-8").toString().split(",")) {
+			try(
+				ZipInputStream zis = new ZipInputStream(new FileInputStream(selectedFile), Charset.forName(cs));
+			) {					
 				for(ZipEntry ze = zis.getNextEntry(); ze != null; ze = zis.getNextEntry()){
 					if (ze.isDirectory()) continue;
 					String key = ze.getName();
@@ -105,14 +102,16 @@ public class ZipAnalyzer extends DefaultImporter
 					stats.setVal(ZipStatsItem.Extra, ze.getExtra());
 					Date d = new Date(ze.getTime());
 					stats.setVal(ZipStatsItem.Date, df.format(d));
-					CharsetDetector detector = new CharsetDetector();
-					detector.setText(key.getBytes());
-					stats.setVal(ZipStatsItem.Charset, detector.detect().toString());
+					stats.setVal(ZipStatsItem.Charset, cs);
 					types.put(key, stats);
 				}
+				
+				break;
 			} catch (Exception e) {
 				System.err.println(e.getMessage());
 			}
+			
+		}
 
 		return new ActionResult(selectedFile, selectedFile.getName(), this.toString(), details, types, true, timer.getDuration());
 	}  // end of ActionResult


### PR DESCRIPTION
This change is an attempt to analyze the encoding of a zip entry, but the functions do not seem to support that capability.

From the Import Tab, choose the Zip Analyzer.  Set an ordered list of Charsets to use for parsing.
![image](https://user-images.githubusercontent.com/1111057/110394417-454ecb80-8021-11eb-9094-75c5cdd91cd6.png)

Verify the zip table of contents
![image](https://user-images.githubusercontent.com/1111057/110394488-60b9d680-8021-11eb-92be-954b46b9cb8a.png)
